### PR TITLE
docs: add .env.example file and update README with configuration inst…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Rename this file to .env and fill in the values
+
+# GITHUB TOKEN READ ACCESS ONLY
+GITHUB_TOKEN=

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ All commands are run from the root of the project, from a terminal:
 | `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `npm run astro -- --help` | Get help using the Astro CLI                     |
 
-## 👀 Want to learn more?
+## ⚙️ .env Configuration for Contributions
 
-Check out [Starlight’s docs](https://starlight.astro.build/), read [the Astro documentation](https://docs.astro.build), or jump into the [Astro Discord server](https://astro.build/chat).
+To use the contributions component, you need to set up a `.env` file with your GitHub read-only token.
+
+1. Copy `.env.example` and rename it to `.env` in the root of the project.
+2. Get a [GitHub Personal Access Token](https://github.com/settings/tokens) with read-only permissions.
+3. Add your token to the `GITHUB_TOKEN` variable in the `.env` file:
+
+   ```
+   GITHUB_TOKEN=your_token_here
+   ```
+
+This allows the contributions component to securely access public


### PR DESCRIPTION
This pull request improves the setup experience for contributors by adding guidance and configuration for using a GitHub token. The most important changes are grouped below:

Environment setup improvements:

* Added a new `.env.example` file to provide a template for environment variables, specifically for the `GITHUB_TOKEN` required for read-only GitHub access.

Documentation updates:

* Updated the `README.md` with a new section detailing how to configure the `.env` file and obtain a GitHub Personal Access Token for contributions